### PR TITLE
Removed "android:supportsRtl"

### DIFF
--- a/easypermissions/src/main/AndroidManifest.xml
+++ b/easypermissions/src/main/AndroidManifest.xml
@@ -1,10 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.example.easypermissions">
-
-    <application
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
-
+<manifest package="com.google.example.easypermissions">
+    <application/>
 </manifest>


### PR DESCRIPTION
Removed "android:supportsRtl" attribute from manifest because of "Manifest merger failed"

adding tools:replace"android:supportsRtl" to my application element didn't fix the problem.