### PR TITLE
Remove FragmentCompat to lower minSDK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "pub.devrel.easypermissions.sample"
-        minSdkVersion 13
+        minSdkVersion 9
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"

--- a/easypermissions/build.gradle
+++ b/easypermissions/build.gradle
@@ -6,7 +6,7 @@ android {
     buildToolsVersion "23.0.2"
 
     defaultConfig {
-        minSdkVersion 13
+        minSdkVersion 9
         targetSdkVersion 23
         versionCode 1
         versionName "$mavenVersion"
@@ -21,7 +21,6 @@ android {
 
 dependencies {
     compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.android.support:support-v13:23.1.1'
 }
 
 apply from: 'maven.gradle'

--- a/easypermissions/constants.gradle
+++ b/easypermissions/constants.gradle
@@ -6,7 +6,7 @@ ext {
 
     mavenGroup = 'pub.devrel'
     mavenArtifactId = 'easypermissions'
-    mavenVersion = '0.1.1'
+    mavenVersion = '0.1.2'
 
     bintrayOrg = 'easygoogle'
 }

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
@@ -19,7 +19,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.pm.PackageManager;
-import android.support.v13.app.FragmentCompat;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
@@ -39,8 +38,7 @@ public class EasyPermissions {
     private static final String TAG = "EasyPermissions";
 
     public interface PermissionCallbacks extends
-            ActivityCompat.OnRequestPermissionsResultCallback,
-            FragmentCompat.OnRequestPermissionsResultCallback {
+            ActivityCompat.OnRequestPermissionsResultCallback {
 
         void onPermissionsGranted(List<String> perms);
 


### PR DESCRIPTION
Use of FragmentCompat was redundant when only supporting
support v4 Fragments as arguments.

Change-Id: I8ba0c00af05562fa9c6fd02923c484611b45a384