### PR TITLE
Use start activity for result to start app settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,41 @@ user in this situation and direct them to the system setting screen for your app
     public void onPermissionsDenied(int requestCode, List<String> perms) {
         Log.d(TAG, "onPermissionsDenied:" + requestCode + ":" + perms.size());
 
+        // Handle negative button on click listener. Pass null if you don't want to handle it.
+        DialogInterface.OnClickListener cancelButtonListener = new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                // Let's show a toast
+                Toast.makeText(getContext(), R.string.settings_dialog_canceled, Toast.LENGTH_SHORT)
+                        .show();
+            }
+        };
+
         // (Optional) Check whether the user denied permissions and checked NEVER ASK AGAIN.
         // This will display a dialog directing them to enable the permission in app settings.
-        EasyPermissions.checkDeniedPermissionsNeverAskAgain(this,
+        EasyPermissions.checkDeniedPermissionsNeverAskAgain(
+                this,
          		getString(R.string.rationale_ask_again),
-                R.string.setting, R.string.cancel, perms);
+                R.string.setting,
+                R.string.cancel,
+                cancelButtonListener,
+                perms
+        );
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        // Do something after user returned from app settings screen. User may be
+        // changed/updated the permissions. Let's check whether the user has some permissions or not
+        // after returned from settings screen
+        if (requestCode == EasyPermissions.SETTINGS_REQ_CODE) {
+            boolean hasSomePermissions = EasyPermissions.hasPermissions(
+                    getContext(), somePermissions
+            );
+
+            // Do something with the updated permissions
+        }
     }
 ```

--- a/app/src/main/java/pub/devrel/easypermissions/sample/MainActivity.java
+++ b/app/src/main/java/pub/devrel/easypermissions/sample/MainActivity.java
@@ -16,6 +16,7 @@
 package pub.devrel.easypermissions.sample;
 
 import android.Manifest;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
@@ -56,6 +57,18 @@ public class MainActivity extends AppCompatActivity implements
                 locationAndContactsTask();
             }
         });
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (requestCode == EasyPermissions.SETTINGS_REQ_CODE) {
+            // Do something after user returned from app settings screen
+            // Let's show Toast for example
+            Toast.makeText(this, R.string.returned_from_app_settings_to_activity, Toast.LENGTH_SHORT)
+                    .show();
+        }
     }
 
     @AfterPermissionGranted(RC_CAMERA_PERM)

--- a/app/src/main/java/pub/devrel/easypermissions/sample/MainActivity.java
+++ b/app/src/main/java/pub/devrel/easypermissions/sample/MainActivity.java
@@ -104,6 +104,6 @@ public class MainActivity extends AppCompatActivity implements
         // This will display a dialog directing them to enable the permission in app settings.
         EasyPermissions.checkDeniedPermissionsNeverAskAgain(this,
                 getString(R.string.rationale_ask_again),
-                R.string.setting, R.string.cancel, perms);
+                R.string.setting, R.string.cancel, null, perms);
     }
 }

--- a/app/src/main/java/pub/devrel/easypermissions/sample/MainActivity.java
+++ b/app/src/main/java/pub/devrel/easypermissions/sample/MainActivity.java
@@ -63,12 +63,33 @@ public class MainActivity extends AppCompatActivity implements
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
+        // Do something after user returned from app settings screen. User may be
+        // changed/updated the permissions. In this sample, we could check whether the user has
+        // changed/updated permission for camera, access fine location, or read contacts.
         if (requestCode == EasyPermissions.SETTINGS_REQ_CODE) {
-            // Do something after user returned from app settings screen
-            // Let's show Toast for example
-            Toast.makeText(this, R.string.returned_from_app_settings_to_activity, Toast.LENGTH_SHORT)
+            // Check the changed/updated permissions manually. Let's show toast.
+            Toast.makeText(this, getUpdatedPermissionsText(), Toast.LENGTH_SHORT)
                     .show();
         }
+    }
+
+    private String getUpdatedPermissionsText() {
+        boolean hasCameraPermission = EasyPermissions.hasPermissions(
+                this, Manifest.permission.CAMERA
+        );
+        boolean hasAccessFineLocationPermission = EasyPermissions.hasPermissions(
+                this, Manifest.permission.ACCESS_FINE_LOCATION
+        );
+        boolean hasReadContactsPermission = EasyPermissions.hasPermissions(
+                this, Manifest.permission.READ_CONTACTS
+        );
+
+        return String.format(
+                getString(R.string.has_some_permissions),
+                hasCameraPermission,
+                hasAccessFineLocationPermission,
+                hasReadContactsPermission
+        );
     }
 
     @AfterPermissionGranted(RC_CAMERA_PERM)

--- a/app/src/main/java/pub/devrel/easypermissions/sample/MainActivity.java
+++ b/app/src/main/java/pub/devrel/easypermissions/sample/MainActivity.java
@@ -63,33 +63,12 @@ public class MainActivity extends AppCompatActivity implements
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
-        // Do something after user returned from app settings screen. User may be
-        // changed/updated the permissions. In this sample, we could check whether the user has
-        // changed/updated permission for camera, access fine location, or read contacts.
         if (requestCode == EasyPermissions.SETTINGS_REQ_CODE) {
-            // Check the changed/updated permissions manually. Let's show toast.
-            Toast.makeText(this, getUpdatedPermissionsText(), Toast.LENGTH_SHORT)
+            // Do something after user returned from app settings screen
+            // Let's show Toast for example
+            Toast.makeText(this, R.string.returned_from_app_settings_to_activity, Toast.LENGTH_SHORT)
                     .show();
         }
-    }
-
-    private String getUpdatedPermissionsText() {
-        boolean hasCameraPermission = EasyPermissions.hasPermissions(
-                this, Manifest.permission.CAMERA
-        );
-        boolean hasAccessFineLocationPermission = EasyPermissions.hasPermissions(
-                this, Manifest.permission.ACCESS_FINE_LOCATION
-        );
-        boolean hasReadContactsPermission = EasyPermissions.hasPermissions(
-                this, Manifest.permission.READ_CONTACTS
-        );
-
-        return String.format(
-                getString(R.string.has_some_permissions),
-                hasCameraPermission,
-                hasAccessFineLocationPermission,
-                hasReadContactsPermission
-        );
     }
 
     @AfterPermissionGranted(RC_CAMERA_PERM)

--- a/app/src/main/java/pub/devrel/easypermissions/sample/MainFragment.java
+++ b/app/src/main/java/pub/devrel/easypermissions/sample/MainFragment.java
@@ -45,10 +45,18 @@ public class MainFragment extends Fragment implements
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
+        // Do something after user returned from app settings screen. User may be
+        // changed/updated the permissions. Let's check whether the user has changed sms
+        // permission or not after returned from settings screen
         if (requestCode == EasyPermissions.SETTINGS_REQ_CODE) {
-            // Do something after user returned from app settings screen
-            // Let's show Toast for example
-            Toast.makeText(getContext(), R.string.returned_from_app_settings_to_fragment, Toast.LENGTH_SHORT)
+            boolean hasReadSmsPermission = EasyPermissions.hasPermissions(
+                    getContext(), Manifest.permission.READ_SMS
+            );
+            String hasReadSmsPermissionText = String.format(
+                    getString(R.string.has_read_sms_permission), hasReadSmsPermission
+            );
+
+            Toast.makeText(getContext(), hasReadSmsPermissionText, Toast.LENGTH_SHORT)
                     .show();
         }
     }

--- a/app/src/main/java/pub/devrel/easypermissions/sample/MainFragment.java
+++ b/app/src/main/java/pub/devrel/easypermissions/sample/MainFragment.java
@@ -2,6 +2,7 @@ package pub.devrel.easypermissions.sample;
 
 import android.Manifest;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
@@ -38,6 +39,18 @@ public class MainFragment extends Fragment implements
         });
 
         return v;
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (requestCode == EasyPermissions.SETTINGS_REQ_CODE) {
+            // Do something after user returned from app settings screen
+            // Let's show Toast for example
+            Toast.makeText(getContext(), R.string.returned_from_app_settings_to_fragment, Toast.LENGTH_SHORT)
+                    .show();
+        }
     }
 
     @Override

--- a/app/src/main/java/pub/devrel/easypermissions/sample/MainFragment.java
+++ b/app/src/main/java/pub/devrel/easypermissions/sample/MainFragment.java
@@ -1,6 +1,7 @@
 package pub.devrel.easypermissions.sample;
 
 import android.Manifest;
+import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
@@ -68,10 +69,20 @@ public class MainFragment extends Fragment implements
     public void onPermissionsDenied(int requestCode, List<String> perms) {
         Log.d(TAG, "onPermissionsDenied:" + requestCode + ":" + perms.size());
 
+        // Handle negative button on click listener
+        DialogInterface.OnClickListener onClickListener = new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                // Let's show a toast
+                Toast.makeText(getContext(), R.string.settings_dialog_canceled, Toast.LENGTH_SHORT)
+                        .show();
+            }
+        };
+
         // (Optional) Check whether the user denied permissions and checked NEVER ASK AGAIN.
         // This will display a dialog directing them to enable the permission in app settings.
         EasyPermissions.checkDeniedPermissionsNeverAskAgain(this,
                 getString(R.string.rationale_ask_again),
-                R.string.setting, R.string.cancel, perms);
+                R.string.setting, R.string.cancel, onClickListener, perms);
     }
 }

--- a/app/src/main/java/pub/devrel/easypermissions/sample/MainFragment.java
+++ b/app/src/main/java/pub/devrel/easypermissions/sample/MainFragment.java
@@ -52,8 +52,8 @@ public class MainFragment extends Fragment implements
             boolean hasReadSmsPermission = EasyPermissions.hasPermissions(
                     getContext(), Manifest.permission.READ_SMS
             );
-            String hasReadSmsPermissionText = String.format(
-                    getString(R.string.has_read_sms_permission), hasReadSmsPermission
+            String hasReadSmsPermissionText = getString(
+                    R.string.has_read_sms_permission, hasReadSmsPermission
             );
 
             Toast.makeText(getContext(), hasReadSmsPermissionText, Toast.LENGTH_SHORT)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,5 @@
     <string name="rationale_ask_again">This app may not work correctly without the requested permissions. Open the app settings screen to modify app permissions.</string>
     <string name="setting">Settings</string>
     <string name="cancel">Cancel</string>
+    <string name="settings_dialog_canceled">Settings dialog canceled</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,6 @@
     <string name="setting">Settings</string>
     <string name="cancel">Cancel</string>
     <string name="settings_dialog_canceled">Settings dialog canceled</string>
+    <string name="returned_from_app_settings_to_fragment">Returned from app settings to MainFragment</string>
+    <string name="returned_from_app_settings_to_activity">Returned from app settings to MainActivity</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,7 +7,6 @@
     <string name="setting">Settings</string>
     <string name="cancel">Cancel</string>
     <string name="settings_dialog_canceled">Settings dialog canceled</string>
+    <string name="returned_from_app_settings_to_activity">Returned from app settings to MainActivity</string>
     <string name="has_read_sms_permission">Has read sms permission: %b</string>
-    <string name="has_some_permissions">Has camera permission: %1$b\nHas access fine location permission: %2$b\nHas read contacts permission: %3$b
-    </string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="setting">Settings</string>
     <string name="cancel">Cancel</string>
     <string name="settings_dialog_canceled">Settings dialog canceled</string>
-    <string name="returned_from_app_settings_to_fragment">Returned from app settings to MainFragment</string>
-    <string name="returned_from_app_settings_to_activity">Returned from app settings to MainActivity</string>
+    <string name="has_read_sms_permission">Has read sms permission: %b</string>
+    <string name="has_some_permissions">Has camera permission: %1$b\nHas access fine location permission: %2$b\nHas read contacts permission: %3$b
+    </string>
 </resources>

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
@@ -220,7 +220,9 @@ public class EasyPermissions {
      *
      * @param object                        the calling Activity or Fragment.
      * @param deniedPerms                   the set of denied permissions.
-     * @param negativeButtonOnClickListener negative button on click listener, can be null
+     * @param negativeButtonOnClickListener negative button on click listener. If the
+     *                                      user click the negative button, then this listener will
+     *                                      be called. Pass null if you don't want to handle it.
      * @return {@code true} if user denied at least one permission with the flag NEVER ASK AGAIN.
      */
     public static boolean checkDeniedPermissionsNeverAskAgain(final Object object,

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
@@ -42,7 +42,7 @@ import java.util.List;
  */
 public class EasyPermissions {
 
-    public static final int SETTINGS_REQ_CODE = 7;
+    public static final int SETTINGS_REQ_CODE = 16061;
 
     private static final String TAG = "EasyPermissions";
 

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
@@ -42,6 +42,8 @@ import java.util.List;
  */
 public class EasyPermissions {
 
+    public static final int SETTINGS_REQ_CODE = 7;
+
     private static final String TAG = "EasyPermissions";
 
     public interface PermissionCallbacks extends
@@ -207,7 +209,11 @@ public class EasyPermissions {
 
     /**
      * If user denied permissions with the flag NEVER ASK AGAIN, open a dialog explaining the
-     * permissions rationale again and directing the user to the app settings.
+     * permissions rationale again and directing the user to the app settings. After the user
+     * returned to the app, {@link Activity#onActivityResult(int, int, Intent)} or
+     * {@link Fragment#onActivityResult(int, int, Intent)} or
+     * {@link android.app.Fragment#onActivityResult(int, int, Intent)} will be called with
+     * {@value #SETTINGS_REQ_CODE} as requestCode
      *
      * NOTE: use of this method is optional, should be called from
      * {@link PermissionCallbacks#onPermissionsDenied(int, List)}
@@ -217,11 +223,12 @@ public class EasyPermissions {
      * @param negativeButtonOnClickListener negative button on click listener, can be null
      * @return {@code true} if user denied at least one permission with the flag NEVER ASK AGAIN.
      */
-    public static boolean checkDeniedPermissionsNeverAskAgain(Object object, String rationale,
-                                                           @StringRes int positiveButton,
-                                                           @StringRes int negativeButton,
-                                                           DialogInterface.OnClickListener negativeButtonOnClickListener,
-                                                           List<String> deniedPerms) {
+    public static boolean checkDeniedPermissionsNeverAskAgain(final Object object,
+                                                              String rationale,
+                                                              @StringRes int positiveButton,
+                                                              @StringRes int negativeButton,
+                                                              DialogInterface.OnClickListener negativeButtonOnClickListener,
+                                                              List<String> deniedPerms) {
         boolean shouldShowRationale;
         for (String perm : deniedPerms) {
             shouldShowRationale = shouldShowRequestPermissionRationale(object, perm);
@@ -239,7 +246,7 @@ public class EasyPermissions {
                                 Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
                                 Uri uri = Uri.fromParts("package", activity.getPackageName(), null);
                                 intent.setData(uri);
-                                activity.startActivity(intent);
+                                startAppSettingsScreen(object, intent);
                             }
                         })
                         .setNegativeButton(negativeButton, negativeButtonOnClickListener)
@@ -289,6 +296,18 @@ public class EasyPermissions {
             return ((android.app.Fragment) object).getActivity();
         } else {
             return null;
+        }
+    }
+
+    @TargetApi(11)
+    private static void startAppSettingsScreen(Object object,
+                                               Intent intent) {
+        if (object instanceof Activity) {
+            ((Activity) object).startActivityForResult(intent, SETTINGS_REQ_CODE);
+        } else if (object instanceof Fragment) {
+            ((Fragment) object).startActivityForResult(intent, SETTINGS_REQ_CODE);
+        } else if (object instanceof android.app.Fragment) {
+            ((android.app.Fragment) object).startActivityForResult(intent, SETTINGS_REQ_CODE);
         }
     }
 

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
@@ -212,13 +212,15 @@ public class EasyPermissions {
      * NOTE: use of this method is optional, should be called from
      * {@link PermissionCallbacks#onPermissionsDenied(int, List)}
      *
-     * @param object      the calling Activity or Fragment.
-     * @param deniedPerms the set of denied permissions.
+     * @param object                        the calling Activity or Fragment.
+     * @param deniedPerms                   the set of denied permissions.
+     * @param negativeButtonOnClickListener negative button on click listener, can be null
      * @return {@code true} if user denied at least one permission with the flag NEVER ASK AGAIN.
      */
     public static boolean checkDeniedPermissionsNeverAskAgain(Object object, String rationale,
                                                            @StringRes int positiveButton,
                                                            @StringRes int negativeButton,
+                                                           DialogInterface.OnClickListener negativeButtonOnClickListener,
                                                            List<String> deniedPerms) {
         boolean shouldShowRationale;
         for (String perm : deniedPerms) {
@@ -240,7 +242,7 @@ public class EasyPermissions {
                                 activity.startActivity(intent);
                             }
                         })
-                        .setNegativeButton(negativeButton, null)
+                        .setNegativeButton(negativeButton, negativeButtonOnClickListener)
                         .create();
                 dialog.show();
 


### PR DESCRIPTION
As the title says, use start activity for result to start app settings screen instead of start activity. This will let the user knows when they returned from app settings screen. So, they will be able to handle the permissions update from app settings.

This pull request was branched from #26 