### PR TITLE
Do not require PermissionCallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,10 @@ dependencies {
 
 ### Basic
 
-To begin using EasyPermissions, have your Activity (or Fragment) implement the 
-`EasyPermissions.PermissionCallbacks` and override the following methods:
+To begin using EasyPermissions, have your `Activity` (or `Fragment`) override the `onRequestPermissionsResult` method:
 
 ```java
-public class MainActivity extends AppCompatActivity
-    implements EasyPermissions.PermissionCallbacks {
+public class MainActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -33,22 +31,11 @@ public class MainActivity extends AppCompatActivity
     @Override
     public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-    
+
         // Forward results to EasyPermissions
         EasyPermissions.onRequestPermissionsResult(requestCode, permissions, grantResults, this);
     }
 
-    @Override
-    public void onPermissionsGranted(int requestCode, List<String> list) {
-        // Some permissions have been granted
-        // ...
-    }
-
-    @Override
-    public void onPermissionsDenied(int requestCode, List<String> list) {
-        // Some permissions have been denied
-        // ...
-    }
 }
 ```
 
@@ -83,6 +70,41 @@ The example below shows how to request permissions for a method that requires bo
                     RC_CAMERA_AND_WIFI, perms);
         }
     }
+```
+
+Optionally, for a finer control, you can have your `Activity` / `Framgment` implement
+the `PermissionCallbacks` interface.
+
+```java
+public class MainActivity extends AppCompatActivity
+    implements EasyPermissions.PermissionCallbacks {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+
+        // Forward results to EasyPermissions
+        EasyPermissions.onRequestPermissionsResult(requestCode, permissions, grantResults, this);
+    }
+
+    @Override
+    public void onPermissionsGranted(int requestCode, List<String> list) {
+        // Some permissions have been granted
+        // ...
+    }
+
+    @Override
+    public void onPermissionsDenied(int requestCode, List<String> list) {
+        // Some permissions have been denied
+        // ...
+    }
+}
 ```
 
 ### Required Permissions

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
@@ -122,7 +122,6 @@ public class EasyPermissions {
                                           final int requestCode, final String... perms) {
 
         checkCallingObjectSuitability(object);
-        final PermissionCallbacks callbacks = (PermissionCallbacks) object;
 
         boolean shouldShowRationale = false;
         for (String perm : perms) {
@@ -148,7 +147,9 @@ public class EasyPermissions {
                         @Override
                         public void onClick(DialogInterface dialog, int which) {
                             // act as if the permissions were denied
-                            callbacks.onPermissionsDenied(requestCode, Arrays.asList(perms));
+                            if (object instanceof PermissionCallbacks) {
+                                ((PermissionCallbacks) object).onPermissionsDenied(requestCode, Arrays.asList(perms));
+                            }
                         }
                     }).create();
             dialog.show();
@@ -177,7 +178,6 @@ public class EasyPermissions {
                                                   int[] grantResults, Object object) {
 
         checkCallingObjectSuitability(object);
-        PermissionCallbacks callbacks = (PermissionCallbacks) object;
 
         // Make a collection of granted and denied permissions from the request.
         ArrayList<String> granted = new ArrayList<>();
@@ -194,12 +194,16 @@ public class EasyPermissions {
         // Report granted permissions, if any.
         if (!granted.isEmpty()) {
             // Notify callbacks
-            callbacks.onPermissionsGranted(requestCode, granted);
+            if (object instanceof PermissionCallbacks) {
+                ((PermissionCallbacks) object).onPermissionsGranted(requestCode, granted);
+            }
         }
 
         // Report denied permissions, if any.
         if (!denied.isEmpty()) {
-            callbacks.onPermissionsDenied(requestCode, denied);
+            if (object instanceof PermissionCallbacks) {
+                ((PermissionCallbacks) object).onPermissionsDenied(requestCode, denied);
+            }
         }
 
         // If 100% successful, call annotated methods
@@ -298,7 +302,7 @@ public class EasyPermissions {
         } else if (object instanceof Fragment) {
             ((Fragment) object).requestPermissions(perms, requestCode);
         } else if (object instanceof android.app.Fragment) {
-            ((android.app.Fragment) object).requestPermissions(perms, requestCode);
+            ((android.app.Fragment) object).requestPermissions(perms, requestCode);;
         }
     }
 
@@ -373,11 +377,6 @@ public class EasyPermissions {
             } else {
                 throw new IllegalArgumentException("Caller must be an Activity or a Fragment.");
             }
-        }
-
-        // Make sure Object implements callbacks
-        if (!(object instanceof PermissionCallbacks)) {
-            throw new IllegalArgumentException("Caller must implement PermissionCallbacks.");
         }
     }
 

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
@@ -65,7 +65,7 @@ public class EasyPermissions {
      * is not yet granted.
      */
     public static boolean hasPermissions(Context context, String... perms) {
-        // Always return true for SDK < M, let the system deal with the permissions 
+        // Always return true for SDK < M, let the system deal with the permissions
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             Log.w(TAG, "hasPermissions: API version < M, returning true by default");
             return true;
@@ -302,7 +302,7 @@ public class EasyPermissions {
         } else if (object instanceof Fragment) {
             ((Fragment) object).requestPermissions(perms, requestCode);
         } else if (object instanceof android.app.Fragment) {
-            ((android.app.Fragment) object).requestPermissions(perms, requestCode);;
+            ((android.app.Fragment) object).requestPermissions(perms, requestCode);
         }
     }
 


### PR DESCRIPTION
Fix for #19.

Made changes to `checkCallingObjectSuitability` to not require `PermissionCallbacks`. Placed `instanceof` checks for `PermissionCallbacks` in `requestPermissions` and `onRequestPermissionsResult` before calling `onPermissionsGranted` and `onPermissionsDenied`.