### PR TITLE
Add new methods to avoid showing rationale

### DIFF
--- a/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
@@ -19,12 +19,8 @@ import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.net.Uri;
 import android.os.Build;
-import android.provider.Settings;
-import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
@@ -127,6 +123,63 @@ public class EasyPermissions {
                     shouldShowRationale || shouldShowRequestPermissionRationale(object, perm);
         }
 
+        requestPermissions(object, rationale,
+                positiveButton,
+                negativeButton,
+                requestCode,
+                shouldShowRationale,
+                perms);
+    }
+
+    /**
+     * Request a set of permissions, without showing any rationale.
+     *
+     * @param object      Activity or Fragment requesting permissions. Should implement
+     *                    {@link android.support.v4.app.ActivityCompat.OnRequestPermissionsResultCallback}
+     *                    or
+     *                    {@link android.support.v13.app.FragmentCompat.OnRequestPermissionsResultCallback}
+     * @param requestCode request code to track this request, must be < 256.
+     * @param perms       a set of permissions to be requested.
+     */
+    public static void requestPermissions(final Object object,
+                                          final int requestCode, final String... perms) {
+        requestPermissions(object,
+                android.R.string.ok,
+                android.R.string.cancel,
+                requestCode, perms);
+    }
+
+    /**
+     * Request a set of permissions, without showing any rationale.
+     *
+     * @param object         Activity or Fragment requesting permissions. Should implement
+     *                       {@link android.support.v4.app.ActivityCompat.OnRequestPermissionsResultCallback}
+     *                       or
+     *                       {@link android.support.v13.app.FragmentCompat.OnRequestPermissionsResultCallback}
+     * @param positiveButton custom text for positive button
+     * @param negativeButton custom text for negative button
+     * @param requestCode    request code to track this request, must be < 256.
+     * @param perms          a set of permissions to be requested.
+     */
+    public static void requestPermissions(final Object object,
+                                          @StringRes int positiveButton,
+                                          @StringRes int negativeButton,
+                                          final int requestCode, final String... perms) {
+        checkCallingObjectSuitability(object);
+
+        requestPermissions(object, null,
+                positiveButton,
+                negativeButton,
+                requestCode, false, perms);
+    }
+
+    private static void requestPermissions(final Object object, String rationale,
+                                           @StringRes int positiveButton,
+                                           @StringRes int negativeButton,
+                                           final int requestCode,
+                                           final boolean shouldShowRationale,
+                                           final String... perms) {
+
         if (shouldShowRationale) {
             Activity activity = getActivity(object);
             if (null == activity) {
@@ -160,9 +213,10 @@ public class EasyPermissions {
     /**
      * Check if at least one permission in the list of denied permissions has been permanently
      * denied (user clicked "Never ask again").
-     * @param object Activity or Fragment requesting permissions.
+     *
+     * @param object            Activity or Fragment requesting permissions.
      * @param deniedPermissions list of denied permissions, usually from
-     *        {@link PermissionCallbacks#onPermissionsDenied(int, List)}
+     *                          {@link PermissionCallbacks#onPermissionsDenied(int, List)}
      * @return {@code true} if at least one permission in the list was permanently denied.
      */
     public static boolean somePermissionPermanentlyDenied(Object object,
@@ -179,7 +233,8 @@ public class EasyPermissions {
 
     /**
      * Check if a permission has been permanently denied (user clicked "Never ask again").
-     * @param object Activity or Fragment requesting permissions.
+     *
+     * @param object           Activity or Fragment requesting permissions.
      * @param deniedPermission denied permission.
      * @return {@code true} if the permissions has been permanently denied.
      */


### PR DESCRIPTION
Hello,

I added 2 public methods. The idea of that pull request is to provide a way to not show any rationale if we do not want any. In my case, in my app, I do not feel the need to have that message showing up. Any questions or comments?

Thank you,
Carl