### PR TITLE
retaining rationale dialog on orientation changes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.1'
 
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.1'
     }
 }

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/AppSettingsDialog.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/AppSettingsDialog.java
@@ -38,6 +38,7 @@ public class AppSettingsDialog {
         // Create empty builder
         AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(context);
 
+        dialogBuilder.setCancelable(false);
         // Set rationale
         dialogBuilder.setMessage(rationale);
 

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
@@ -18,24 +18,20 @@ package pub.devrel.easypermissions;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
-import android.content.DialogInterface;
-import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.net.Uri;
 import android.os.Build;
-import android.provider.Settings;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AlertDialog;
+import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -44,6 +40,7 @@ import java.util.List;
 public class EasyPermissions {
 
     private static final String TAG = "EasyPermissions";
+    private static final String DIALG_TAG = "RationaleDialogFragment";
 
     public interface PermissionCallbacks extends
             ActivityCompat.OnRequestPermissionsResultCallback {
@@ -57,12 +54,13 @@ public class EasyPermissions {
     /**
      * Check if the calling context has a set of permissions.
      *
-     * @param context the calling context.
-     * @param perms   one ore more permissions, such as {@code android.Manifest.permission.CAMERA}.
-     * @return true if all permissions are already granted, false if at least one permission
-     * is not yet granted.
+     * @param context
+     *         the calling context.
+     * @param perms
+     *         one ore more permissions, such as {@code android.Manifest.permission.CAMERA}.
+     * @return true if all permissions are already granted, false if at least one permission is not yet granted.
      */
-    public static boolean hasPermissions(Context context, String... perms) {
+    public static boolean hasPermissions(@NonNull Context context, @NonNull String... perms) {
         // Always return true for SDK < M, let the system deal with the permissions
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             Log.w(TAG, "hasPermissions: API version < M, returning true by default");
@@ -83,17 +81,20 @@ public class EasyPermissions {
     /**
      * Request a set of permissions, showing rationale if the system requests it.
      *
-     * @param object      Activity or Fragment requesting permissions. Should implement
-     *                    {@link android.support.v4.app.ActivityCompat.OnRequestPermissionsResultCallback}
-     *                    or
-     *                    {@link android.support.v13.app.FragmentCompat.OnRequestPermissionsResultCallback}
-     * @param rationale   a message explaining why the application needs this set of permissions, will
-     *                    be displayed if the user rejects the request the first time.
-     * @param requestCode request code to track this request, must be < 256.
-     * @param perms       a set of permissions to be requested.
+     * @param object
+     *         Activity or Fragment requesting permissions. Should implement
+     *         {@link android.support.v4.app.ActivityCompat.OnRequestPermissionsResultCallback}
+     *         or {@link android.support.v13.app.FragmentCompat.OnRequestPermissionsResultCallback}
+     * @param rationale
+     *         a message explaining why the application needs this set of permissions, will be displayed if the user rejects the request the first
+     *         time.
+     * @param requestCode
+     *         request code to track this request, must be < 256.
+     * @param perms
+     *         a set of permissions to be requested.
      */
-    public static void requestPermissions(final Object object, String rationale,
-                                          final int requestCode, final String... perms) {
+    public static void requestPermissions(@NonNull final Object object, @NonNull String rationale,
+                                          final int requestCode, @NonNull final String... perms) {
         requestPermissions(object, rationale,
                 android.R.string.ok,
                 android.R.string.cancel,
@@ -103,21 +104,25 @@ public class EasyPermissions {
     /**
      * Request a set of permissions, showing rationale if the system requests it.
      *
-     * @param object         Activity or Fragment requesting permissions. Should implement
-     *                       {@link android.support.v4.app.ActivityCompat.OnRequestPermissionsResultCallback}
-     *                       or
-     *                       {@link android.support.v13.app.FragmentCompat.OnRequestPermissionsResultCallback}
-     * @param rationale      a message explaining why the application needs this set of permissions, will
-     *                       be displayed if the user rejects the request the first time.
-     * @param positiveButton custom text for positive button
-     * @param negativeButton custom text for negative button
-     * @param requestCode    request code to track this request, must be < 256.
-     * @param perms          a set of permissions to be requested.
+     * @param object
+     *         Activity or Fragment requesting permissions. Should implement
+     *         {@link android.support.v4.app.ActivityCompat.OnRequestPermissionsResultCallback}
+     *         or {@link android.support.v13.app.FragmentCompat.OnRequestPermissionsResultCallback}
+     * @param rationale
+     *         a message explaining why the application needs this set of permissions, will be displayed if the user rejects the request the first
+     *         time.
+     * @param positiveButton
+     *         custom text for positive button
+     * @param negativeButton
+     *         custom text for negative button
+     * @param requestCode
+     *         request code to track this request, must be < 256.
+     * @param perms
+     *         a set of permissions to be requested.
      */
-    public static void requestPermissions(final Object object, String rationale,
-                                          @StringRes int positiveButton,
-                                          @StringRes int negativeButton,
-                                          final int requestCode, final String... perms) {
+    public static void requestPermissions(@NonNull final Object object, @NonNull String rationale,
+                                          @StringRes int positiveButton, @StringRes int negativeButton,
+                                          final int requestCode, @NonNull final String... perms) {
 
         checkCallingObjectSuitability(object);
 
@@ -128,45 +133,69 @@ public class EasyPermissions {
         }
 
         if (shouldShowRationale) {
-            Activity activity = getActivity(object);
-            if (null == activity) {
-                return;
+            if (object instanceof AppCompatActivity) {
+                showAppCompatRationaleDialog((AppCompatActivity) object, requestCode,
+                        perms, positiveButton, negativeButton, rationale);
+            } else if (object instanceof Activity) {
+                showRationaleDialog((Activity) object, requestCode, perms,
+                        positiveButton, negativeButton, rationale);
+            } else if (object instanceof Fragment) {
+                showAppCompatRationaleDialogByFragment((Fragment) object, requestCode, perms,
+                        positiveButton, negativeButton, rationale);
+            } else if (object instanceof android.app.Fragment) {
+                showRationaleDialogByFragment((android.app.Fragment) object, requestCode, perms,
+                        positiveButton, negativeButton, rationale);
+            } else {
+                throw new RuntimeException("Object is not assigned to either an Activity or Fragment.");
             }
-
-            AlertDialog dialog = new AlertDialog.Builder(activity)
-                    .setMessage(rationale)
-                    .setPositiveButton(positiveButton, new DialogInterface.OnClickListener() {
-                        @Override
-                        public void onClick(DialogInterface dialog, int which) {
-                            executePermissionsRequest(object, perms, requestCode);
-                        }
-                    })
-                    .setNegativeButton(negativeButton, new DialogInterface.OnClickListener() {
-                        @Override
-                        public void onClick(DialogInterface dialog, int which) {
-                            // act as if the permissions were denied
-                            if (object instanceof PermissionCallbacks) {
-                                ((PermissionCallbacks) object).onPermissionsDenied(requestCode, Arrays.asList(perms));
-                            }
-                        }
-                    }).create();
-            dialog.show();
         } else {
             executePermissionsRequest(object, perms, requestCode);
         }
     }
 
 
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+    private static void showRationaleDialogByFragment(@NonNull android.app.Fragment object, int requestCode,
+                                                      @NonNull String[] perms, @StringRes int positiveButton,
+                                                      @StringRes int negativeButton, @NonNull String rationale) {
+        RationaleDialogFragment.newInstance(positiveButton, negativeButton, rationale, requestCode, perms)
+                .show(object.getChildFragmentManager(), DIALG_TAG);
+    }
+
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+    private static void showRationaleDialog(@NonNull Activity object, int requestCode,
+                                            @NonNull String[] perms, @StringRes int positiveButton,
+                                            @StringRes int negativeButton, @NonNull String rationale) {
+        RationaleDialogFragment.newInstance(positiveButton, negativeButton, rationale, requestCode, perms)
+                .show(object.getFragmentManager(), DIALG_TAG);
+    }
+
+    private static void showAppCompatRationaleDialogByFragment(@NonNull Fragment object, int requestCode,
+                                                               @NonNull String[] perms, @StringRes int positiveButton,
+                                                               @StringRes int negativeButton, @NonNull String rationale) {
+        RationaleAppCompatDialogFragment.newInstance(positiveButton, negativeButton, rationale, requestCode, perms)
+                .show(object.getChildFragmentManager(), DIALG_TAG);
+    }
+
+    private static void showAppCompatRationaleDialog(@NonNull AppCompatActivity object, int requestCode,
+                                                     @NonNull String[] perms, @StringRes int positiveButton,
+                                                     @StringRes int negativeButton, @NonNull String rationale) {
+        RationaleAppCompatDialogFragment.newInstance(positiveButton, negativeButton, rationale, requestCode, perms)
+                .show(object.getSupportFragmentManager(), DIALG_TAG);
+    }
+
+
     /**
-     * Check if at least one permission in the list of denied permissions has been permanently
-     * denied (user clicked "Never ask again").
-     * @param object Activity or Fragment requesting permissions.
-     * @param deniedPermissions list of denied permissions, usually from
-     *        {@link PermissionCallbacks#onPermissionsDenied(int, List)}
+     * Check if at least one permission in the list of denied permissions has been permanently denied (user clicked "Never ask again").
+     *
+     * @param object
+     *         Activity or Fragment requesting permissions.
+     * @param deniedPermissions
+     *         list of denied permissions, usually from {@link PermissionCallbacks#onPermissionsDenied(int, List)}
      * @return {@code true} if at least one permission in the list was permanently denied.
      */
-    public static boolean somePermissionPermanentlyDenied(Object object,
-                                                          List<String> deniedPermissions) {
+    public static boolean somePermissionPermanentlyDenied(@NonNull Object object,
+                                                          @NonNull List<String> deniedPermissions) {
         for (String deniedPermission : deniedPermissions) {
             if (permissionPermanentlyDenied(object, deniedPermission)) {
                 return true;
@@ -179,32 +208,38 @@ public class EasyPermissions {
 
     /**
      * Check if a permission has been permanently denied (user clicked "Never ask again").
-     * @param object Activity or Fragment requesting permissions.
-     * @param deniedPermission denied permission.
+     *
+     * @param object
+     *         Activity or Fragment requesting permissions.
+     * @param deniedPermission
+     *         denied permission.
      * @return {@code true} if the permissions has been permanently denied.
      */
-    public static boolean permissionPermanentlyDenied(Object object, String deniedPermission) {
+    public static boolean permissionPermanentlyDenied(@NonNull Object object,
+                                                      @NonNull String deniedPermission) {
         return !shouldShowRequestPermissionRationale(object, deniedPermission);
     }
 
 
     /**
-     * Handle the result of a permission request, should be called from the calling Activity's
-     * {@link android.support.v4.app.ActivityCompat.OnRequestPermissionsResultCallback#onRequestPermissionsResult(int, String[], int[])}
-     * method.
+     * Handle the result of a permission request, should be called from the calling Activity's {@link android.support.v4.app.ActivityCompat
+     * .OnRequestPermissionsResultCallback#onRequestPermissionsResult(int, String[], int[])} method.
      * <p>
-     * If any permissions were granted or denied, the {@code object} will receive the appropriate
-     * callbacks through {@link PermissionCallbacks} and methods annotated with
-     * {@link AfterPermissionGranted} will be run if appropriate.
+     * If any permissions were granted or denied, the {@code object} will receive the appropriate callbacks through {@link PermissionCallbacks} and
+     * methods annotated with {@link AfterPermissionGranted} will be run if appropriate.
      *
-     * @param requestCode  requestCode argument to permission result callback.
-     * @param permissions  permissions argument to permission result callback.
-     * @param grantResults grantResults argument to permission result callback.
-     * @param receivers    an array of objects that have a method annotated with {@link AfterPermissionGranted}
-     *                     or implement {@link PermissionCallbacks}.
+     * @param requestCode
+     *         requestCode argument to permission result callback.
+     * @param permissions
+     *         permissions argument to permission result callback.
+     * @param grantResults
+     *         grantResults argument to permission result callback.
+     * @param receivers
+     *         an array of objects that have a method annotated with {@link AfterPermissionGranted} or implement {@link PermissionCallbacks}.
      */
-    public static void onRequestPermissionsResult(int requestCode, String[] permissions,
-                                                  int[] grantResults, Object... receivers) {
+    public static void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+                                                  @NonNull int[] grantResults,
+                                                  @NonNull Object... receivers) {
 
         // Make a collection of granted and denied permissions from the request.
         ArrayList<String> granted = new ArrayList<>();
@@ -243,7 +278,8 @@ public class EasyPermissions {
     }
 
     @TargetApi(23)
-    private static boolean shouldShowRequestPermissionRationale(Object object, String perm) {
+    private static boolean shouldShowRequestPermissionRationale(@NonNull Object object,
+                                                                @NonNull String perm) {
         if (object instanceof Activity) {
             return ActivityCompat.shouldShowRequestPermissionRationale((Activity) object, perm);
         } else if (object instanceof Fragment) {
@@ -256,9 +292,8 @@ public class EasyPermissions {
     }
 
     @TargetApi(23)
-    private static void executePermissionsRequest(Object object, String[] perms, int requestCode) {
+    static void executePermissionsRequest(@NonNull Object object, @NonNull String[] perms, int requestCode) {
         checkCallingObjectSuitability(object);
-
         if (object instanceof Activity) {
             ActivityCompat.requestPermissions((Activity) object, perms, requestCode);
         } else if (object instanceof Fragment) {
@@ -269,7 +304,7 @@ public class EasyPermissions {
     }
 
     @TargetApi(11)
-    private static Activity getActivity(Object object) {
+    private static Activity getActivity(@NonNull Object object) {
         if (object instanceof Activity) {
             return ((Activity) object);
         } else if (object instanceof Fragment) {
@@ -281,7 +316,7 @@ public class EasyPermissions {
         }
     }
 
-    private static void runAnnotatedMethods(Object object, int requestCode) {
+    private static void runAnnotatedMethods(@NonNull Object object, int requestCode) {
         Class clazz = object.getClass();
         if (isUsingAndroidAnnotations(object)) {
             clazz = clazz.getSuperclass();
@@ -313,13 +348,15 @@ public class EasyPermissions {
         }
     }
 
-    private static void checkCallingObjectSuitability(Object object) {
+    private static void checkCallingObjectSuitability(@Nullable Object object) {
+        if (object == null) {
+            throw new NullPointerException("Activity or Fragment should not be null");
+        }
         // Make sure Object is an Activity or Fragment
         boolean isActivity = object instanceof Activity;
         boolean isSupportFragment = object instanceof Fragment;
         boolean isAppFragment = object instanceof android.app.Fragment;
         boolean isMinSdkM = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;
-
         if (!(isSupportFragment || isActivity || (isAppFragment && isMinSdkM))) {
             if (isAppFragment) {
                 throw new IllegalArgumentException(
@@ -330,11 +367,10 @@ public class EasyPermissions {
         }
     }
 
-    private static boolean isUsingAndroidAnnotations(Object object) {
+    private static boolean isUsingAndroidAnnotations(@NonNull Object object) {
         if (!object.getClass().getSimpleName().endsWith("_")) {
             return false;
         }
-
         try {
             Class clazz = Class.forName("org.androidannotations.api.view.HasViews");
             return clazz.isInstance(object);

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
@@ -40,7 +40,7 @@ import java.util.List;
 public class EasyPermissions {
 
     private static final String TAG = "EasyPermissions";
-    private static final String DIALG_TAG = "RationaleDialogFragment";
+    private static final String DIALOG_TAG = "RationaleDialogFragment";
 
     public interface PermissionCallbacks extends
             ActivityCompat.OnRequestPermissionsResultCallback {
@@ -159,7 +159,7 @@ public class EasyPermissions {
                                                       @NonNull String[] perms, @StringRes int positiveButton,
                                                       @StringRes int negativeButton, @NonNull String rationale) {
         RationaleDialogFragment.newInstance(positiveButton, negativeButton, rationale, requestCode, perms)
-                .show(object.getChildFragmentManager(), DIALG_TAG);
+                .show(object.getChildFragmentManager(), DIALOG_TAG);
     }
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
@@ -167,21 +167,21 @@ public class EasyPermissions {
                                             @NonNull String[] perms, @StringRes int positiveButton,
                                             @StringRes int negativeButton, @NonNull String rationale) {
         RationaleDialogFragment.newInstance(positiveButton, negativeButton, rationale, requestCode, perms)
-                .show(object.getFragmentManager(), DIALG_TAG);
+                .show(object.getFragmentManager(), DIALOG_TAG);
     }
 
     private static void showAppCompatRationaleDialogByFragment(@NonNull Fragment object, int requestCode,
                                                                @NonNull String[] perms, @StringRes int positiveButton,
                                                                @StringRes int negativeButton, @NonNull String rationale) {
         RationaleAppCompatDialogFragment.newInstance(positiveButton, negativeButton, rationale, requestCode, perms)
-                .show(object.getChildFragmentManager(), DIALG_TAG);
+                .show(object.getChildFragmentManager(), DIALOG_TAG);
     }
 
     private static void showAppCompatRationaleDialog(@NonNull AppCompatActivity object, int requestCode,
                                                      @NonNull String[] perms, @StringRes int positiveButton,
                                                      @StringRes int negativeButton, @NonNull String rationale) {
         RationaleAppCompatDialogFragment.newInstance(positiveButton, negativeButton, rationale, requestCode, perms)
-                .show(object.getSupportFragmentManager(), DIALG_TAG);
+                .show(object.getSupportFragmentManager(), DIALOG_TAG);
     }
 
 

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
@@ -294,7 +294,7 @@ public class EasyPermissions {
                     // Method must be void so that we can invoke it
                     if (method.getParameterTypes().length > 0) {
                         throw new RuntimeException(
-                                "Cannot execute non-void method " + method.getName());
+                                "Cannot execute method " + method.getName() + " because it is non-void method and/or has input parameters.");
                     }
 
                     try {

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleAppCompatDialogFragment.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleAppCompatDialogFragment.java
@@ -64,6 +64,7 @@ public class RationaleAppCompatDialogFragment extends DialogFragment implements 
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         setupArguments();
         return new AlertDialog.Builder(getContext())
+                .setCancelable(false)
                 .setOnCancelListener(this)
                 .setPositiveButton(positiveButton, this)
                 .setNegativeButton(negativeButton, this)

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleAppCompatDialogFragment.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleAppCompatDialogFragment.java
@@ -41,13 +41,6 @@ public class RationaleAppCompatDialogFragment extends DialogFragment implements 
         return dialogFragment;
     }
 
-    static RationaleAppCompatDialogFragment newInstance(@NonNull String rationaleMsg,
-                                                        int requestCode,
-                                                        @NonNull String[] permissions) {
-        return newInstance(android.R.string.ok, android.R.string.cancel, rationaleMsg,
-                requestCode, permissions);
-    }
-
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
@@ -66,20 +59,10 @@ public class RationaleAppCompatDialogFragment extends DialogFragment implements 
         permissionCallbacks = null;
     }
 
-    @Override
-    public void onSaveInstanceState(Bundle bundle) {
-        super.onSaveInstanceState(bundle);
-        bundle.putInt("positiveButton", positiveButton);
-        bundle.putInt("negativeButton", negativeButton);
-        bundle.putInt("requestCode", requestCode);
-        bundle.putStringArray("permissions", permissions);
-        bundle.putString("rationaleMsg", rationaleMsg);
-    }
-
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        setupArguments(savedInstanceState);
+        setupArguments();
         return new AlertDialog.Builder(getContext())
                 .setOnCancelListener(this)
                 .setPositiveButton(positiveButton, this)
@@ -106,13 +89,8 @@ public class RationaleAppCompatDialogFragment extends DialogFragment implements 
         dismiss();
     }
 
-    private void setupArguments(Bundle savedInstanceState) {
-        Bundle bundle;
-        if (savedInstanceState == null) {
-            bundle = getArguments();
-        } else {
-            bundle = savedInstanceState;
-        }
+    private void setupArguments() {
+        Bundle bundle = getArguments();
         positiveButton = bundle.getInt("positiveButton");
         negativeButton = bundle.getInt("negativeButton");
         rationaleMsg = bundle.getString("rationaleMsg");

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleAppCompatDialogFragment.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleAppCompatDialogFragment.java
@@ -11,9 +11,10 @@ import android.support.v7.app.AlertDialog;
 
 import java.util.Arrays;
 
-import static pub.devrel.easypermissions.EasyPermissions.executePermissionsRequest;
 
-
+/**
+ * RationaleAppCompatDialogFragment that is being used where the calling Activity/Fragment is from the support Library
+ */
 public class RationaleAppCompatDialogFragment extends DialogFragment implements Dialog.OnClickListener {
 
     private EasyPermissions.PermissionCallbacks permissionCallbacks;
@@ -24,11 +25,11 @@ public class RationaleAppCompatDialogFragment extends DialogFragment implements 
     private String rationaleMsg;
     private String[] permissions;
 
-    public static RationaleAppCompatDialogFragment newInstance(@StringRes int positiveButton,
-                                                               @StringRes int negativeButton,
-                                                               @NonNull String rationaleMsg,
-                                                               int requestCode,
-                                                               @NonNull String[] permissions) {
+    static RationaleAppCompatDialogFragment newInstance(@StringRes int positiveButton,
+                                                        @StringRes int negativeButton,
+                                                        @NonNull String rationaleMsg,
+                                                        int requestCode,
+                                                        @NonNull String[] permissions) {
         RationaleAppCompatDialogFragment dialogFragment = new RationaleAppCompatDialogFragment();
         Bundle bundle = new Bundle();
         bundle.putInt("positiveButton", positiveButton);
@@ -40,14 +41,15 @@ public class RationaleAppCompatDialogFragment extends DialogFragment implements 
         return dialogFragment;
     }
 
-    public static RationaleAppCompatDialogFragment newInstance(@NonNull String rationaleMsg,
-                                                               int requestCode,
-                                                               @NonNull String[] permissions) {
+    static RationaleAppCompatDialogFragment newInstance(@NonNull String rationaleMsg,
+                                                        int requestCode,
+                                                        @NonNull String[] permissions) {
         return newInstance(android.R.string.ok, android.R.string.cancel, rationaleMsg,
                 requestCode, permissions);
     }
 
-    @Override public void onAttach(Context context) {
+    @Override
+    public void onAttach(Context context) {
         super.onAttach(context);
         if (getParentFragment() != null && getParentFragment() instanceof EasyPermissions.PermissionCallbacks) {
             permissionCallbacks = (EasyPermissions.PermissionCallbacks) getParentFragment();
@@ -58,12 +60,14 @@ public class RationaleAppCompatDialogFragment extends DialogFragment implements 
         }
     }
 
-    @Override public void onDetach() {
+    @Override
+    public void onDetach() {
         super.onDetach();
         permissionCallbacks = null;
     }
 
-    @Override public void onSaveInstanceState(Bundle bundle) {
+    @Override
+    public void onSaveInstanceState(Bundle bundle) {
         super.onSaveInstanceState(bundle);
         bundle.putInt("positiveButton", positiveButton);
         bundle.putInt("negativeButton", negativeButton);
@@ -72,26 +76,30 @@ public class RationaleAppCompatDialogFragment extends DialogFragment implements 
         bundle.putString("rationaleMsg", rationaleMsg);
     }
 
-    @NonNull @Override public Dialog onCreateDialog(Bundle savedInstanceState) {
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
         setupArguments(savedInstanceState);
-        AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
-        builder.setOnCancelListener(this);
-        builder.setPositiveButton(positiveButton, this);
-        builder.setNegativeButton(negativeButton, this);
-        builder.setMessage(rationaleMsg);
-        return builder.create();
+        return new AlertDialog.Builder(getContext())
+                .setOnCancelListener(this)
+                .setPositiveButton(positiveButton, this)
+                .setNegativeButton(negativeButton, this)
+                .setMessage(rationaleMsg)
+                .create();
     }
 
-    @Override public void onCancel(DialogInterface dialog) {
+    @Override
+    public void onCancel(DialogInterface dialog) {
         super.onCancel(dialog);
         if (permissionCallbacks != null) {
             permissionCallbacks.onPermissionsDenied(requestCode, Arrays.asList(permissions));
         }
     }
 
-    @Override public void onClick(DialogInterface dialog, int which) {
+    @Override
+    public void onClick(DialogInterface dialog, int which) {
         if (which == Dialog.BUTTON_POSITIVE) {
-            executePermissionsRequest(this, permissions, requestCode);
+            EasyPermissions.executePermissionsRequest(this, permissions, requestCode);
         } else {
             permissionCallbacks.onPermissionsDenied(requestCode, Arrays.asList(permissions));
         }

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleAppCompatDialogFragment.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleAppCompatDialogFragment.java
@@ -1,0 +1,114 @@
+package pub.devrel.easypermissions;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.StringRes;
+import android.support.v4.app.DialogFragment;
+import android.support.v7.app.AlertDialog;
+
+import java.util.Arrays;
+
+import static pub.devrel.easypermissions.EasyPermissions.executePermissionsRequest;
+
+
+public class RationaleAppCompatDialogFragment extends DialogFragment implements Dialog.OnClickListener {
+
+    private EasyPermissions.PermissionCallbacks permissionCallbacks;
+
+    private int positiveButton;
+    private int negativeButton;
+    private int requestCode;
+    private String rationaleMsg;
+    private String[] permissions;
+
+    public static RationaleAppCompatDialogFragment newInstance(@StringRes int positiveButton,
+                                                               @StringRes int negativeButton,
+                                                               @NonNull String rationaleMsg,
+                                                               int requestCode,
+                                                               @NonNull String[] permissions) {
+        RationaleAppCompatDialogFragment dialogFragment = new RationaleAppCompatDialogFragment();
+        Bundle bundle = new Bundle();
+        bundle.putInt("positiveButton", positiveButton);
+        bundle.putInt("negativeButton", negativeButton);
+        bundle.putString("rationaleMsg", rationaleMsg);
+        bundle.putInt("requestCode", requestCode);
+        bundle.putStringArray("permissions", permissions);
+        dialogFragment.setArguments(bundle);
+        return dialogFragment;
+    }
+
+    public static RationaleAppCompatDialogFragment newInstance(@NonNull String rationaleMsg,
+                                                               int requestCode,
+                                                               @NonNull String[] permissions) {
+        return newInstance(android.R.string.ok, android.R.string.cancel, rationaleMsg,
+                requestCode, permissions);
+    }
+
+    @Override public void onAttach(Context context) {
+        super.onAttach(context);
+        if (getParentFragment() != null && getParentFragment() instanceof EasyPermissions.PermissionCallbacks) {
+            permissionCallbacks = (EasyPermissions.PermissionCallbacks) getParentFragment();
+        } else if (context instanceof EasyPermissions.PermissionCallbacks) {
+            permissionCallbacks = (EasyPermissions.PermissionCallbacks) context;
+        } else {
+            throw new RuntimeException("Activity or Fragment should implement PermissionCallbacks");
+        }
+    }
+
+    @Override public void onDetach() {
+        super.onDetach();
+        permissionCallbacks = null;
+    }
+
+    @Override public void onSaveInstanceState(Bundle bundle) {
+        super.onSaveInstanceState(bundle);
+        bundle.putInt("positiveButton", positiveButton);
+        bundle.putInt("negativeButton", negativeButton);
+        bundle.putInt("requestCode", requestCode);
+        bundle.putStringArray("permissions", permissions);
+        bundle.putString("rationaleMsg", rationaleMsg);
+    }
+
+    @NonNull @Override public Dialog onCreateDialog(Bundle savedInstanceState) {
+        setupArguments(savedInstanceState);
+        AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
+        builder.setOnCancelListener(this);
+        builder.setPositiveButton(positiveButton, this);
+        builder.setNegativeButton(negativeButton, this);
+        builder.setMessage(rationaleMsg);
+        return builder.create();
+    }
+
+    @Override public void onCancel(DialogInterface dialog) {
+        super.onCancel(dialog);
+        if (permissionCallbacks != null) {
+            permissionCallbacks.onPermissionsDenied(requestCode, Arrays.asList(permissions));
+        }
+    }
+
+    @Override public void onClick(DialogInterface dialog, int which) {
+        if (which == Dialog.BUTTON_POSITIVE) {
+            executePermissionsRequest(this, permissions, requestCode);
+        } else {
+            permissionCallbacks.onPermissionsDenied(requestCode, Arrays.asList(permissions));
+        }
+        dismiss();
+    }
+
+    private void setupArguments(Bundle savedInstanceState) {
+        Bundle bundle;
+        if (savedInstanceState == null) {
+            bundle = getArguments();
+        } else {
+            bundle = savedInstanceState;
+        }
+        positiveButton = bundle.getInt("positiveButton");
+        negativeButton = bundle.getInt("negativeButton");
+        rationaleMsg = bundle.getString("rationaleMsg");
+        requestCode = bundle.getInt("requestCode");
+        permissions = bundle.getStringArray("permissions");
+    }
+}

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleDialogFragment.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleDialogFragment.java
@@ -44,12 +44,6 @@ public class RationaleDialogFragment extends DialogFragment implements Dialog.On
         return dialogFragment;
     }
 
-    static RationaleDialogFragment newInstance(@NonNull String rationaleMsg,
-                                               int requestCode,
-                                               @NonNull String[] permissions) {
-        return newInstance(android.R.string.ok, android.R.string.cancel, rationaleMsg, requestCode, permissions);
-    }
-
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
@@ -68,20 +62,10 @@ public class RationaleDialogFragment extends DialogFragment implements Dialog.On
         permissionCallbacks = null;
     }
 
-    @Override
-    public void onSaveInstanceState(Bundle bundle) {
-        super.onSaveInstanceState(bundle);
-        bundle.putInt("positiveButton", positiveButton);
-        bundle.putInt("negativeButton", negativeButton);
-        bundle.putInt("requestCode", requestCode);
-        bundle.putStringArray("permissions", permissions);
-        bundle.putString("rationaleMsg", rationaleMsg);
-    }
-
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        setupArguments(savedInstanceState);
+        setupArguments();
         return new AlertDialog.Builder(getActivity())
                 .setOnCancelListener(this)
                 .setPositiveButton(positiveButton, this)
@@ -108,13 +92,8 @@ public class RationaleDialogFragment extends DialogFragment implements Dialog.On
         dismiss();
     }
 
-    private void setupArguments(Bundle savedInstanceState) {
-        Bundle bundle;
-        if (savedInstanceState == null) {
-            bundle = getArguments();
-        } else {
-            bundle = savedInstanceState;
-        }
+    private void setupArguments() {
+        Bundle bundle = getArguments();
         positiveButton = bundle.getInt("positiveButton");
         negativeButton = bundle.getInt("negativeButton");
         rationaleMsg = bundle.getString("rationaleMsg");

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleDialogFragment.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleDialogFragment.java
@@ -1,0 +1,115 @@
+package pub.devrel.easypermissions;
+
+import android.annotation.TargetApi;
+import android.app.Dialog;
+import android.app.DialogFragment;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.StringRes;
+import android.support.v7.app.AlertDialog;
+
+import java.util.Arrays;
+
+import static pub.devrel.easypermissions.EasyPermissions.executePermissionsRequest;
+
+
+@TargetApi(17)
+public class RationaleDialogFragment extends DialogFragment implements Dialog.OnClickListener {
+
+    private EasyPermissions.PermissionCallbacks permissionCallbacks;
+
+    private int positiveButton;
+    private int negativeButton;
+    private int requestCode;
+    private String rationaleMsg;
+    private String[] permissions;
+
+    public static RationaleDialogFragment newInstance(@StringRes int positiveButton,
+                                                      @StringRes int negativeButton,
+                                                      @NonNull String rationaleMsg,
+                                                      int requestCode,
+                                                      @NonNull String[] permissions) {
+        RationaleDialogFragment dialogFragment = new RationaleDialogFragment();
+        Bundle bundle = new Bundle();
+        bundle.putInt("positiveButton", positiveButton);
+        bundle.putInt("negativeButton", negativeButton);
+        bundle.putString("rationaleMsg", rationaleMsg);
+        bundle.putInt("requestCode", requestCode);
+        bundle.putStringArray("permissions", permissions);
+        dialogFragment.setArguments(bundle);
+        return dialogFragment;
+    }
+
+    public static RationaleDialogFragment newInstance(@NonNull String rationaleMsg,
+                                                      int requestCode,
+                                                      @NonNull String[] permissions) {
+        return newInstance(android.R.string.ok, android.R.string.cancel, rationaleMsg, requestCode, permissions);
+    }
+
+    @Override public void onAttach(Context context) {
+        super.onAttach(context);
+        if (getParentFragment() != null && getParentFragment() instanceof EasyPermissions.PermissionCallbacks) {
+            permissionCallbacks = (EasyPermissions.PermissionCallbacks) getParentFragment();
+        } else if (context instanceof EasyPermissions.PermissionCallbacks) {
+            permissionCallbacks = (EasyPermissions.PermissionCallbacks) context;
+        } else {
+            throw new RuntimeException("Activity or Fragment should implement PermissionCallbacks");
+        }
+    }
+
+    @Override public void onDetach() {
+        super.onDetach();
+        permissionCallbacks = null;
+    }
+
+    @Override public void onSaveInstanceState(Bundle bundle) {
+        super.onSaveInstanceState(bundle);
+        bundle.putInt("positiveButton", positiveButton);
+        bundle.putInt("negativeButton", negativeButton);
+        bundle.putInt("requestCode", requestCode);
+        bundle.putStringArray("permissions", permissions);
+        bundle.putString("rationaleMsg", rationaleMsg);
+    }
+
+    @NonNull @Override public Dialog onCreateDialog(Bundle savedInstanceState) {
+        setupArguments(savedInstanceState);
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setOnCancelListener(this);
+        builder.setPositiveButton(positiveButton, this);
+        builder.setNegativeButton(negativeButton, this);
+        builder.setMessage(rationaleMsg);
+        return builder.create();
+    }
+
+    @Override public void onCancel(DialogInterface dialog) {
+        super.onCancel(dialog);
+        if (permissionCallbacks != null) {
+            permissionCallbacks.onPermissionsDenied(requestCode, Arrays.asList(permissions));
+        }
+    }
+
+    @Override public void onClick(DialogInterface dialog, int which) {
+        if (which == Dialog.BUTTON_POSITIVE) {
+            executePermissionsRequest(this, permissions, requestCode);
+        } else {
+            permissionCallbacks.onPermissionsDenied(requestCode, Arrays.asList(permissions));
+        }
+        dismiss();
+    }
+
+    private void setupArguments(Bundle savedInstanceState) {
+        Bundle bundle;
+        if (savedInstanceState == null) {
+            bundle = getArguments();
+        } else {
+            bundle = savedInstanceState;
+        }
+        positiveButton = bundle.getInt("positiveButton");
+        negativeButton = bundle.getInt("negativeButton");
+        rationaleMsg = bundle.getString("rationaleMsg");
+        requestCode = bundle.getInt("requestCode");
+        permissions = bundle.getStringArray("permissions");
+    }
+}

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleDialogFragment.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleDialogFragment.java
@@ -66,6 +66,7 @@ public class RationaleDialogFragment extends DialogFragment implements Dialog.On
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         setupArguments();
         return new AlertDialog.Builder(getActivity())
+                .setCancelable(false)
                 .setOnCancelListener(this)
                 .setPositiveButton(positiveButton, this)
                 .setNegativeButton(negativeButton, this)

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleDialogFragment.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleDialogFragment.java
@@ -13,11 +13,10 @@ import android.support.v7.app.AlertDialog;
 import java.util.Arrays;
 
 
-@TargetApi(17)
-
 /**
  * RationaleDialogFragment that is being used where the calling Activity/Fragment is not from the support Library
  */
+@TargetApi(17)
 public class RationaleDialogFragment extends DialogFragment implements Dialog.OnClickListener {
 
     private EasyPermissions.PermissionCallbacks permissionCallbacks;

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleDialogFragment.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleDialogFragment.java
@@ -12,10 +12,12 @@ import android.support.v7.app.AlertDialog;
 
 import java.util.Arrays;
 
-import static pub.devrel.easypermissions.EasyPermissions.executePermissionsRequest;
-
 
 @TargetApi(17)
+
+/**
+ * RationaleDialogFragment that is being used where the calling Activity/Fragment is not from the support Library
+ */
 public class RationaleDialogFragment extends DialogFragment implements Dialog.OnClickListener {
 
     private EasyPermissions.PermissionCallbacks permissionCallbacks;
@@ -26,11 +28,11 @@ public class RationaleDialogFragment extends DialogFragment implements Dialog.On
     private String rationaleMsg;
     private String[] permissions;
 
-    public static RationaleDialogFragment newInstance(@StringRes int positiveButton,
-                                                      @StringRes int negativeButton,
-                                                      @NonNull String rationaleMsg,
-                                                      int requestCode,
-                                                      @NonNull String[] permissions) {
+    static RationaleDialogFragment newInstance(@StringRes int positiveButton,
+                                               @StringRes int negativeButton,
+                                               @NonNull String rationaleMsg,
+                                               int requestCode,
+                                               @NonNull String[] permissions) {
         RationaleDialogFragment dialogFragment = new RationaleDialogFragment();
         Bundle bundle = new Bundle();
         bundle.putInt("positiveButton", positiveButton);
@@ -42,13 +44,14 @@ public class RationaleDialogFragment extends DialogFragment implements Dialog.On
         return dialogFragment;
     }
 
-    public static RationaleDialogFragment newInstance(@NonNull String rationaleMsg,
-                                                      int requestCode,
-                                                      @NonNull String[] permissions) {
+    static RationaleDialogFragment newInstance(@NonNull String rationaleMsg,
+                                               int requestCode,
+                                               @NonNull String[] permissions) {
         return newInstance(android.R.string.ok, android.R.string.cancel, rationaleMsg, requestCode, permissions);
     }
 
-    @Override public void onAttach(Context context) {
+    @Override
+    public void onAttach(Context context) {
         super.onAttach(context);
         if (getParentFragment() != null && getParentFragment() instanceof EasyPermissions.PermissionCallbacks) {
             permissionCallbacks = (EasyPermissions.PermissionCallbacks) getParentFragment();
@@ -59,12 +62,14 @@ public class RationaleDialogFragment extends DialogFragment implements Dialog.On
         }
     }
 
-    @Override public void onDetach() {
+    @Override
+    public void onDetach() {
         super.onDetach();
         permissionCallbacks = null;
     }
 
-    @Override public void onSaveInstanceState(Bundle bundle) {
+    @Override
+    public void onSaveInstanceState(Bundle bundle) {
         super.onSaveInstanceState(bundle);
         bundle.putInt("positiveButton", positiveButton);
         bundle.putInt("negativeButton", negativeButton);
@@ -73,26 +78,30 @@ public class RationaleDialogFragment extends DialogFragment implements Dialog.On
         bundle.putString("rationaleMsg", rationaleMsg);
     }
 
-    @NonNull @Override public Dialog onCreateDialog(Bundle savedInstanceState) {
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
         setupArguments(savedInstanceState);
-        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-        builder.setOnCancelListener(this);
-        builder.setPositiveButton(positiveButton, this);
-        builder.setNegativeButton(negativeButton, this);
-        builder.setMessage(rationaleMsg);
-        return builder.create();
+        return new AlertDialog.Builder(getActivity())
+                .setOnCancelListener(this)
+                .setPositiveButton(positiveButton, this)
+                .setNegativeButton(negativeButton, this)
+                .setMessage(rationaleMsg)
+                .create();
     }
 
-    @Override public void onCancel(DialogInterface dialog) {
+    @Override
+    public void onCancel(DialogInterface dialog) {
         super.onCancel(dialog);
         if (permissionCallbacks != null) {
             permissionCallbacks.onPermissionsDenied(requestCode, Arrays.asList(permissions));
         }
     }
 
-    @Override public void onClick(DialogInterface dialog, int which) {
+    @Override
+    public void onClick(DialogInterface dialog, int which) {
         if (which == Dialog.BUTTON_POSITIVE) {
-            executePermissionsRequest(this, permissions, requestCode);
+            EasyPermissions.executePermissionsRequest(this, permissions, requestCode);
         } else {
             permissionCallbacks.onPermissionsDenied(requestCode, Arrays.asList(permissions));
         }


### PR DESCRIPTION
Well, here is the PR as promised, this PR is compatible with the previous versions of EasyPermissions, i've included two new classes which are

- `RationaleDialogFragment` for Framework Fragments & Activity. 
- `RationaleAppCompatDialogFragment` for AppCompat Fragments & AppCompatActivity.

**P.S:** I have messed up the code format abit as tbh its a habit to use `option+command+l` every time i write something.
Please let me know if you need any clarification on anything regards this PR. 