### PR TITLE
Fixed android.app.Fragment callbacks from rationale dialog

### DIFF
--- a/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleDialogClickListener.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleDialogClickListener.java
@@ -33,7 +33,14 @@ class RationaleDialogClickListener implements Dialog.OnClickListener {
                                  RationaleDialogConfig config,
                                  EasyPermissions.PermissionCallbacks callbacks) {
 
-        mHost = dialogFragment.getActivity();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            mHost = dialogFragment.getParentFragment() != null ?
+                    dialogFragment.getParentFragment() :
+                    dialogFragment.getActivity();
+        } else {
+            mHost = dialogFragment.getActivity();
+        }
+
         mConfig = config;
         mCallbacks = callbacks;
     }


### PR DESCRIPTION
Fix for issue #57.

I'm not 100% happy with the fix because it will only work on API > 17. 

But do we really care about API < 17 as the permissions check at runtime appeared on Android Marshmallow?
In any case, we do the same API version check on file RationaleDialogFragment, so it would also need to be fixed.