### PR TITLE
Fixed crash on rationale click listener when using android.app.Fragment

### DIFF
--- a/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleDialogClickListener.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleDialogClickListener.java
@@ -53,7 +53,15 @@ class RationaleDialogClickListener implements Dialog.OnClickListener {
         if (which == Dialog.BUTTON_POSITIVE) {
             if (mHost instanceof Fragment) {
                 ((Fragment) mHost).requestPermissions(mConfig.permissions, mConfig.requestCode);
-            } else { // mHost instance of FragmentActivity
+            } else if (mHost instanceof android.app.Fragment) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    ((android.app.Fragment) mHost)
+                            .requestPermissions(mConfig.permissions, mConfig.requestCode);
+                } else {
+                    throw new IllegalArgumentException(
+                            "Target SDK needs to be greater than 23 if caller is android.app.Fragment");
+                }
+            } else if (mHost instanceof FragmentActivity) {
                 ActivityCompat.requestPermissions(
                         (FragmentActivity) mHost, mConfig.permissions, mConfig.requestCode);
             }


### PR DESCRIPTION
My PR #61 introduced a crash in RationaleDialogClickListener when trying to cast Fragment host as FragmentActivity.

I did not have the time to fully test it but it should be the only regression.