### PR TITLE
Add single method interface to handle granted / denied permissions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,5 +30,8 @@
         <activity
             android:name=".BasicActivity"
             android:exported="true" />
+        <activity
+            android:name=".SingleCallbackActivity"
+            android:exported="true" />
     </application>
 </manifest>

--- a/app/src/main/java/pub/devrel/easypermissions/sample/SingleCallbackActivity.java
+++ b/app/src/main/java/pub/devrel/easypermissions/sample/SingleCallbackActivity.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pub.devrel.easypermissions.sample;
+
+import android.Manifest;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+import android.view.View;
+import android.widget.Toast;
+
+import java.util.List;
+
+import pub.devrel.easypermissions.AfterPermissionGranted;
+import pub.devrel.easypermissions.AppSettingsDialog;
+import pub.devrel.easypermissions.EasyPermissions;
+
+public class SingleCallbackActivity extends AppCompatActivity implements EasyPermissions.PermissionCallback {
+
+    private static final String TAG = "SingleCallbackActivity";
+
+    private static final int RC_CAMERA_PERM = 123;
+    private static final int RC_LOCATION_CONTACTS_PERM = 124;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_single_callback);
+
+        // Button click listener that will request one permission.
+        findViewById(R.id.button_camera).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                cameraTask();
+            }
+        });
+
+        // Button click listener that will request two permissions.
+        findViewById(R.id.button_location_and_wifi).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                locationAndContactsTask();
+            }
+        });
+    }
+
+    @AfterPermissionGranted(RC_CAMERA_PERM)
+    public void cameraTask() {
+        if (EasyPermissions.hasPermissions(this, Manifest.permission.CAMERA)) {
+            // Have permission, do the thing!
+            Toast.makeText(this, "TODO: Camera things", Toast.LENGTH_LONG).show();
+        } else {
+            // Ask for one permission
+            EasyPermissions.requestPermissions(this, getString(R.string.rationale_camera),
+                    RC_CAMERA_PERM, Manifest.permission.CAMERA);
+        }
+    }
+
+    @AfterPermissionGranted(RC_LOCATION_CONTACTS_PERM)
+    public void locationAndContactsTask() {
+        String[] perms = { Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.READ_CONTACTS };
+        if (EasyPermissions.hasPermissions(this, perms)) {
+            // Have permissions, do the thing!
+            Toast.makeText(this, "TODO: Location and Contacts things", Toast.LENGTH_LONG).show();
+        } else {
+            // Ask for both permissions
+            EasyPermissions.requestPermissions(this, getString(R.string.rationale_location_contacts),
+                    RC_LOCATION_CONTACTS_PERM, perms);
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+
+        // EasyPermissions handles the request result.
+        EasyPermissions.onRequestPermissionsResult(requestCode, permissions, grantResults, this);
+    }
+
+    @Override
+    public void onPermissionsResults(int requestCode, List<String> grantedPerms, List<String> deniedPerms) {
+        Log.d(TAG, "onPermissionsResults:" + requestCode + ":granted:" + grantedPerms.size() + ":denied:"+ deniedPerms.size());
+
+        // (Optional) Check whether the user denied any permissions and checked "NEVER ASK AGAIN."
+        // This will display a dialog directing them to enable the permission in app settings.
+        if (EasyPermissions.somePermissionPermanentlyDenied(this, deniedPerms)) {
+            new AppSettingsDialog.Builder(this).build().show();
+        }
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (requestCode == AppSettingsDialog.DEFAULT_SETTINGS_REQ_CODE) {
+            // Do something after user returned from app settings screen, like showing a Toast.
+            Toast.makeText(this, R.string.returned_from_app_settings_to_activity, Toast.LENGTH_SHORT)
+                    .show();
+        }
+    }
+}

--- a/app/src/main/java/pub/devrel/easypermissions/sample/SingleCallbackFragment.java
+++ b/app/src/main/java/pub/devrel/easypermissions/sample/SingleCallbackFragment.java
@@ -1,0 +1,68 @@
+package pub.devrel.easypermissions.sample;
+
+import android.Manifest;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.Fragment;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Toast;
+
+import java.util.List;
+
+import pub.devrel.easypermissions.AfterPermissionGranted;
+import pub.devrel.easypermissions.EasyPermissions;
+
+/**
+ *  Created in {@link R.layout#activity_main}
+ */
+public class SingleCallbackFragment extends Fragment implements EasyPermissions.PermissionCallback {
+
+    private static final String TAG = "SingleCallbackFragment";
+    private static final int RC_SMS_PERM = 122;
+
+    @Override
+    public View onCreateView (LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        super.onCreateView(inflater, container, savedInstanceState);
+
+        // Create view
+        View v =  inflater.inflate(R.layout.fragment_main, container);
+
+        // Button click listener
+        v.findViewById(R.id.button_sms).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                smsTask();
+            }
+        });
+
+        return v;
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+
+        // EasyPermissions handles the request result.
+        EasyPermissions.onRequestPermissionsResult(requestCode, permissions, grantResults, this);
+    }
+
+    @AfterPermissionGranted(RC_SMS_PERM)
+    private void smsTask() {
+        if (EasyPermissions.hasPermissions(getContext(), Manifest.permission.READ_SMS)) {
+            // Have permission, do the thing!
+            Toast.makeText(getActivity(), "TODO: SMS things", Toast.LENGTH_LONG).show();
+        } else {
+            // Request one permission
+            EasyPermissions.requestPermissions(this, getString(R.string.rationale_sms),
+                    RC_SMS_PERM, Manifest.permission.READ_SMS);
+        }
+    }
+
+    @Override
+    public void onPermissionsResults(int requestCode, List<String> grantedPerms, List<String> deniedPerms) {
+        Log.d(TAG, "onPermissionsResults:" + requestCode + ":granted:" + grantedPerms.size() + ":denied:"+ deniedPerms.size());
+    }
+}

--- a/app/src/main/res/layout/activity_single_callback.xml
+++ b/app/src/main/res/layout/activity_single_callback.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin">
+
+    <Button
+        android:id="@+id/button_camera"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/camera" />
+
+    <Button
+        android:id="@+id/button_location_and_wifi"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/location_and_contacts" />
+
+    <fragment
+        android:id="@+id/fragment"
+        android:name="pub.devrel.easypermissions.sample.SingleCallbackFragment"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:layout="@layout/fragment_main" />
+
+</LinearLayout>

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/EasyPermissions.java
@@ -48,6 +48,11 @@ public class EasyPermissions {
 
     }
 
+    public interface PermissionCallback extends ActivityCompat.OnRequestPermissionsResultCallback {
+
+        void onPermissionsResults(int requestCode, List<String> grantedPerms, List<String> deniedPerms);
+    }
+
     private static final String TAG = "EasyPermissions";
     private static final String DIALOG_TAG = "RationaleDialogFragmentCompat";
 
@@ -242,7 +247,7 @@ public class EasyPermissions {
      * String[], int[])} method.
      * <p>
      * If any permissions were granted or denied, the {@code object} will receive the appropriate
-     * callbacks through {@link PermissionCallbacks} and methods annotated with {@link
+     * callbacks through {@link PermissionCallbacks} or {@link PermissionCallback}, and methods annotated with {@link
      * AfterPermissionGranted} will be run if appropriate.
      *
      * @param requestCode  requestCode argument to permission result callback.
@@ -283,6 +288,11 @@ public class EasyPermissions {
                 }
             }
 
+            // Report all requested permissions, granted or denied
+            if (object instanceof PermissionCallback) {
+                ((PermissionCallback) object).onPermissionsResults(requestCode, granted, denied);
+            }
+
             // If 100% successful, call annotated methods
             if (!granted.isEmpty() && denied.isEmpty()) {
                 runAnnotatedMethods(object, requestCode);
@@ -295,8 +305,9 @@ public class EasyPermissions {
      * denied (user clicked "Never ask again").
      *
      * @param activity          {@link Activity} requesting permissions.
-     * @param deniedPermissions list of denied permissions, usually from {@link
-     *                          PermissionCallbacks#onPermissionsDenied(int, List)}
+     * @param deniedPermissions list of denied permissions, usually from
+     *                          {@link PermissionCallbacks#onPermissionsDenied(int, List)} or
+     *                          {@link PermissionCallback#onPermissionsResults(int, List, List)}
      * @return {@code true} if at least one permission in the list was permanently denied.
      */
     public static boolean somePermissionPermanentlyDenied(@NonNull Activity activity,

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleDialogClickListener.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleDialogClickListener.java
@@ -8,6 +8,7 @@ import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 
 /**
@@ -18,6 +19,7 @@ class RationaleDialogClickListener implements Dialog.OnClickListener {
     private Object mHost;
     private RationaleDialogConfig mConfig;
     private EasyPermissions.PermissionCallbacks mCallbacks;
+    private EasyPermissions.PermissionCallback mCallback;
 
     RationaleDialogClickListener(RationaleDialogFragmentCompat compatDialogFragment,
                                  RationaleDialogConfig config,
@@ -29,6 +31,18 @@ class RationaleDialogClickListener implements Dialog.OnClickListener {
 
         mConfig = config;
         mCallbacks = callbacks;
+    }
+
+    RationaleDialogClickListener(RationaleDialogFragmentCompat compatDialogFragment,
+                                 RationaleDialogConfig config,
+                                 EasyPermissions.PermissionCallback callback) {
+
+        mHost = compatDialogFragment.getParentFragment() != null
+                ? compatDialogFragment.getParentFragment()
+                : compatDialogFragment.getActivity();
+
+        mConfig = config;
+        mCallback = callback;
     }
 
     @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
@@ -46,6 +60,23 @@ class RationaleDialogClickListener implements Dialog.OnClickListener {
 
         mConfig = config;
         mCallbacks = callbacks;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
+    RationaleDialogClickListener(RationaleDialogFragment dialogFragment,
+                                 RationaleDialogConfig config,
+                                 EasyPermissions.PermissionCallback callback) {
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            mHost = dialogFragment.getParentFragment() != null ?
+                    dialogFragment.getParentFragment() :
+                    dialogFragment.getActivity();
+        } else {
+            mHost = dialogFragment.getActivity();
+        }
+
+        mConfig = config;
+        mCallback = callback;
     }
 
     @Override
@@ -74,6 +105,9 @@ class RationaleDialogClickListener implements Dialog.OnClickListener {
         if (mCallbacks != null) {
             mCallbacks.onPermissionsDenied(mConfig.requestCode,
                     Arrays.asList(mConfig.permissions));
+        } else if (mCallback != null) {
+            mCallback.onPermissionsResults(mConfig.requestCode,
+                    new ArrayList<String>(), Arrays.asList(mConfig.permissions));
         }
     }
 }

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleDialogFragment.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleDialogFragment.java
@@ -18,6 +18,7 @@ import android.support.annotation.StringRes;
 public class RationaleDialogFragment extends DialogFragment {
 
     private EasyPermissions.PermissionCallbacks mPermissionCallbacks;
+    private EasyPermissions.PermissionCallback mPermissionCallback;
 
     static RationaleDialogFragment newInstance(
             @StringRes int positiveButton, @StringRes int negativeButton,
@@ -42,12 +43,16 @@ public class RationaleDialogFragment extends DialogFragment {
         // getParentFragment() requires API 17 or higher
         boolean isAtLeastJellyBeanMR1 = Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1;
 
-        if (isAtLeastJellyBeanMR1
-                && getParentFragment() != null
-                && getParentFragment() instanceof EasyPermissions.PermissionCallbacks) {
-            mPermissionCallbacks = (EasyPermissions.PermissionCallbacks) getParentFragment();
+        if (isAtLeastJellyBeanMR1 && getParentFragment() != null) {
+            if (getParentFragment() instanceof EasyPermissions.PermissionCallbacks) {
+                mPermissionCallbacks = (EasyPermissions.PermissionCallbacks) getParentFragment();
+            } else if (getParentFragment() instanceof EasyPermissions.PermissionCallback) {
+                mPermissionCallback = (EasyPermissions.PermissionCallback) getParentFragment();
+            }
         } else if (context instanceof EasyPermissions.PermissionCallbacks) {
             mPermissionCallbacks = (EasyPermissions.PermissionCallbacks) context;
+        } else if (context instanceof EasyPermissions.PermissionCallback) {
+            mPermissionCallback = (EasyPermissions.PermissionCallback) context;
         }
     }
 
@@ -55,6 +60,7 @@ public class RationaleDialogFragment extends DialogFragment {
     public void onDetach() {
         super.onDetach();
         mPermissionCallbacks = null;
+        mPermissionCallback = null;
     }
 
     @NonNull
@@ -67,6 +73,12 @@ public class RationaleDialogFragment extends DialogFragment {
         RationaleDialogConfig config = new RationaleDialogConfig(getArguments());
         RationaleDialogClickListener clickListener =
                 new RationaleDialogClickListener(this, config, mPermissionCallbacks);
+
+        if (mPermissionCallbacks == null && mPermissionCallback != null) {
+            clickListener = new RationaleDialogClickListener(this, config, mPermissionCallbacks);
+        } else if (mPermissionCallback != null) {
+            clickListener = new RationaleDialogClickListener(this, config, mPermissionCallback);
+        }
 
         // Create an AlertDialog
         return config.createDialog(getActivity(), clickListener);

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleDialogFragmentCompat.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/RationaleDialogFragmentCompat.java
@@ -17,6 +17,7 @@ import android.support.v7.app.AppCompatDialogFragment;
 public class RationaleDialogFragmentCompat extends AppCompatDialogFragment {
 
     private EasyPermissions.PermissionCallbacks mPermissionCallbacks;
+    private EasyPermissions.PermissionCallback mPermissionCallback;
 
     static RationaleDialogFragmentCompat newInstance(
             @StringRes int positiveButton, @StringRes int negativeButton,
@@ -36,10 +37,16 @@ public class RationaleDialogFragmentCompat extends AppCompatDialogFragment {
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
-        if (getParentFragment() != null && getParentFragment() instanceof EasyPermissions.PermissionCallbacks) {
-            mPermissionCallbacks = (EasyPermissions.PermissionCallbacks) getParentFragment();
+        if (getParentFragment() != null) {
+            if (getParentFragment() instanceof EasyPermissions.PermissionCallbacks) {
+                mPermissionCallbacks = (EasyPermissions.PermissionCallbacks) getParentFragment();
+            } else if (getParentFragment() instanceof EasyPermissions.PermissionCallback) {
+                mPermissionCallback = (EasyPermissions.PermissionCallback) getParentFragment();
+            }
         } else if (context instanceof EasyPermissions.PermissionCallbacks) {
             mPermissionCallbacks = (EasyPermissions.PermissionCallbacks) context;
+        } else if (context instanceof EasyPermissions.PermissionCallback) {
+            mPermissionCallback = (EasyPermissions.PermissionCallback) context;
         }
     }
 
@@ -47,6 +54,7 @@ public class RationaleDialogFragmentCompat extends AppCompatDialogFragment {
     public void onDetach() {
         super.onDetach();
         mPermissionCallbacks = null;
+        mPermissionCallback = null;
     }
 
     @NonNull
@@ -59,6 +67,12 @@ public class RationaleDialogFragmentCompat extends AppCompatDialogFragment {
         RationaleDialogConfig config = new RationaleDialogConfig(getArguments());
         RationaleDialogClickListener clickListener =
                 new RationaleDialogClickListener(this, config, mPermissionCallbacks);
+
+        if (mPermissionCallbacks == null && mPermissionCallback != null) {
+            clickListener = new RationaleDialogClickListener(this, config, mPermissionCallbacks);
+        } else if (mPermissionCallback != null) {
+            clickListener = new RationaleDialogClickListener(this, config, mPermissionCallback);
+        }
 
         // Create an AlertDialog
         return config.createDialog(getContext(), clickListener);


### PR DESCRIPTION
This should resolve #93 in a backwards compatible way.
We should mark the other interface as deprecated if this is preferred interface going forward.