### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ The example below shows how to request permissions for a method that requires bo
     necessary. The request code provided should be unique to this request, and the method
     can take any number of permissions as its final argument.
   * Use of the `AfterPermissionGranted` annotation. This is optional, but provided for
-    convenience. If all of the permissions in a given request are granted, any methods
-    annotated with the proper request code will be executed. This is to simplify the common
+    convenience. If all of the permissions in a given request are granted, *all* methods
+    annotated with the proper request code will be executed(be sure to have an unique request code). The annotated method needs to be *void* and *without input parameters* (instead, you can use *onSaveInstanceState* in order to keep the state of your suppressed parameters). This is to simplify the common
     flow of needing to run the requesting method after all of its permissions have been granted.
     This can also be achieved by adding logic on the `onPermissionsGranted` callback.
 


### PR DESCRIPTION
The method that is annotated with `AfterPermissionGranted` needs to be void and without input parameters so that it can be invoked, as it can create unwanted crashes on permissions granted - EasyPermissions.java line 408 and issue #169.