### PR TITLE
Add setOpenInNewTask() to AppSettingsDialog.Builder

### DIFF
--- a/easypermissions/src/main/java/pub/devrel/easypermissions/AppSettingsDialog.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/AppSettingsDialog.java
@@ -47,7 +47,7 @@ public class AppSettingsDialog implements Parcelable {
     private final String mPositiveButtonText;
     private final String mNegativeButtonText;
     private final int mRequestCode;
-    private final boolean mOpenInNewTask;
+    private final int mIntentFlags;
 
     private Object mActivityOrFragment;
     private Context mContext;
@@ -59,7 +59,7 @@ public class AppSettingsDialog implements Parcelable {
         mPositiveButtonText = in.readString();
         mNegativeButtonText = in.readString();
         mRequestCode = in.readInt();
-        mOpenInNewTask = in.readInt() != 0;
+        mIntentFlags = in.readInt();
     }
 
     private AppSettingsDialog(@NonNull final Object activityOrFragment,
@@ -69,7 +69,7 @@ public class AppSettingsDialog implements Parcelable {
                               @Nullable String positiveButtonText,
                               @Nullable String negativeButtonText,
                               int requestCode,
-                              boolean openInNewTask) {
+                              int intentFlags) {
         setActivityOrFragment(activityOrFragment);
         mThemeResId = themeResId;
         mRationale = rationale;
@@ -77,7 +77,7 @@ public class AppSettingsDialog implements Parcelable {
         mPositiveButtonText = positiveButtonText;
         mNegativeButtonText = negativeButtonText;
         mRequestCode = requestCode;
-        mOpenInNewTask = openInNewTask;
+        mIntentFlags = intentFlags;
     }
 
     static AppSettingsDialog fromIntent(Intent intent, Activity activity) {
@@ -151,11 +151,11 @@ public class AppSettingsDialog implements Parcelable {
         dest.writeString(mPositiveButtonText);
         dest.writeString(mNegativeButtonText);
         dest.writeInt(mRequestCode);
-        dest.writeInt(mOpenInNewTask ? 1 : 0);
+        dest.writeInt(mIntentFlags);
     }
 
-    boolean isOpenInNewTask() {
-        return mOpenInNewTask;
+    int getIntentFlags() {
+        return mIntentFlags;
     }
 
     /**
@@ -332,6 +332,11 @@ public class AppSettingsDialog implements Parcelable {
                     mContext.getString(android.R.string.cancel) : mNegativeButtonText;
             mRequestCode = mRequestCode > 0 ? mRequestCode : DEFAULT_SETTINGS_REQ_CODE;
 
+            int intentFlags = 0;
+            if (mOpenInNewTask) {
+                intentFlags |= Intent.FLAG_ACTIVITY_NEW_TASK;
+            }
+
             return new AppSettingsDialog(
                     mActivityOrFragment,
                     mThemeResId,
@@ -340,7 +345,7 @@ public class AppSettingsDialog implements Parcelable {
                     mPositiveButtonText,
                     mNegativeButtonText,
                     mRequestCode,
-                    mOpenInNewTask);
+                    intentFlags);
         }
 
     }

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/AppSettingsDialog.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/AppSettingsDialog.java
@@ -47,6 +47,7 @@ public class AppSettingsDialog implements Parcelable {
     private final String mPositiveButtonText;
     private final String mNegativeButtonText;
     private final int mRequestCode;
+    private final boolean mOpenInNewTask;
 
     private Object mActivityOrFragment;
     private Context mContext;
@@ -58,6 +59,7 @@ public class AppSettingsDialog implements Parcelable {
         mPositiveButtonText = in.readString();
         mNegativeButtonText = in.readString();
         mRequestCode = in.readInt();
+        mOpenInNewTask = in.readInt() != 0;
     }
 
     private AppSettingsDialog(@NonNull final Object activityOrFragment,
@@ -66,7 +68,8 @@ public class AppSettingsDialog implements Parcelable {
                               @Nullable String title,
                               @Nullable String positiveButtonText,
                               @Nullable String negativeButtonText,
-                              int requestCode) {
+                              int requestCode,
+                              boolean openInNewTask) {
         setActivityOrFragment(activityOrFragment);
         mThemeResId = themeResId;
         mRationale = rationale;
@@ -74,6 +77,7 @@ public class AppSettingsDialog implements Parcelable {
         mPositiveButtonText = positiveButtonText;
         mNegativeButtonText = negativeButtonText;
         mRequestCode = requestCode;
+        mOpenInNewTask = openInNewTask;
     }
 
     static AppSettingsDialog fromIntent(Intent intent, Activity activity) {
@@ -147,6 +151,11 @@ public class AppSettingsDialog implements Parcelable {
         dest.writeString(mPositiveButtonText);
         dest.writeString(mNegativeButtonText);
         dest.writeInt(mRequestCode);
+        dest.writeInt(mOpenInNewTask ? 1 : 0);
+    }
+
+    boolean isOpenInNewTask() {
+        return mOpenInNewTask;
     }
 
     /**
@@ -163,6 +172,7 @@ public class AppSettingsDialog implements Parcelable {
         private String mPositiveButtonText;
         private String mNegativeButtonText;
         private int mRequestCode = -1;
+        private boolean mOpenInNewTask = false;
 
         /**
          * Create a new Builder for an {@link AppSettingsDialog}.
@@ -296,6 +306,17 @@ public class AppSettingsDialog implements Parcelable {
         }
 
         /**
+         * Set whether the settings screen should be opened in a separate task. This is achieved by
+         * setting {@link android.content.Intent#FLAG_ACTIVITY_NEW_TASK#FLAG_ACTIVITY_NEW_TASK} on
+         * the Intent used to open the settings screen.
+         */
+        @NonNull
+        public Builder setOpenInNewTask(boolean openInNewTask) {
+            mOpenInNewTask = openInNewTask;
+            return this;
+        }
+
+        /**
          * Build the {@link AppSettingsDialog} from the specified options. Generally followed by a
          * call to {@link AppSettingsDialog#show()}.
          */
@@ -318,7 +339,8 @@ public class AppSettingsDialog implements Parcelable {
                     mTitle,
                     mPositiveButtonText,
                     mNegativeButtonText,
-                    mRequestCode);
+                    mRequestCode,
+                    mOpenInNewTask);
         }
 
     }

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/AppSettingsDialogHolderActivity.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/AppSettingsDialogHolderActivity.java
@@ -17,16 +17,20 @@ public class AppSettingsDialogHolderActivity extends AppCompatActivity implement
     private static final int APP_SETTINGS_RC = 7534;
 
     private AlertDialog mDialog;
+    private boolean mIsOpenInNewTask;
 
     public static Intent createShowDialogIntent(Context context, AppSettingsDialog dialog) {
-        return new Intent(context, AppSettingsDialogHolderActivity.class)
-                .putExtra(AppSettingsDialog.EXTRA_APP_SETTINGS, dialog);
+        Intent intent = new Intent(context, AppSettingsDialogHolderActivity.class);
+        intent.putExtra(AppSettingsDialog.EXTRA_APP_SETTINGS, dialog);
+        return intent;
     }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mDialog = AppSettingsDialog.fromIntent(getIntent(), this).showDialog(this, this);
+        AppSettingsDialog appSettingsDialog = AppSettingsDialog.fromIntent(getIntent(), this);
+        mIsOpenInNewTask = appSettingsDialog.isOpenInNewTask();
+        mDialog = appSettingsDialog.showDialog(this, this);
     }
 
     @Override
@@ -40,10 +44,12 @@ public class AppSettingsDialogHolderActivity extends AppCompatActivity implement
     @Override
     public void onClick(DialogInterface dialog, int which) {
         if (which == Dialog.BUTTON_POSITIVE) {
-            startActivityForResult(
-                    new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
-                            .setData(Uri.fromParts("package", getPackageName(), null)),
-                    APP_SETTINGS_RC);
+            Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                    .setData(Uri.fromParts("package", getPackageName(), null));
+            if (mIsOpenInNewTask) {
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            }
+            startActivityForResult(intent, APP_SETTINGS_RC);
         } else if (which == Dialog.BUTTON_NEGATIVE) {
             setResult(Activity.RESULT_CANCELED);
             finish();

--- a/easypermissions/src/main/java/pub/devrel/easypermissions/AppSettingsDialogHolderActivity.java
+++ b/easypermissions/src/main/java/pub/devrel/easypermissions/AppSettingsDialogHolderActivity.java
@@ -17,7 +17,7 @@ public class AppSettingsDialogHolderActivity extends AppCompatActivity implement
     private static final int APP_SETTINGS_RC = 7534;
 
     private AlertDialog mDialog;
-    private boolean mIsOpenInNewTask;
+    private int mIntentFlags;
 
     public static Intent createShowDialogIntent(Context context, AppSettingsDialog dialog) {
         Intent intent = new Intent(context, AppSettingsDialogHolderActivity.class);
@@ -29,7 +29,7 @@ public class AppSettingsDialogHolderActivity extends AppCompatActivity implement
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         AppSettingsDialog appSettingsDialog = AppSettingsDialog.fromIntent(getIntent(), this);
-        mIsOpenInNewTask = appSettingsDialog.isOpenInNewTask();
+        mIntentFlags = appSettingsDialog.getIntentFlags();
         mDialog = appSettingsDialog.showDialog(this, this);
     }
 
@@ -46,9 +46,7 @@ public class AppSettingsDialogHolderActivity extends AppCompatActivity implement
         if (which == Dialog.BUTTON_POSITIVE) {
             Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
                     .setData(Uri.fromParts("package", getPackageName(), null));
-            if (mIsOpenInNewTask) {
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            }
+            intent.addFlags(mIntentFlags);
             startActivityForResult(intent, APP_SETTINGS_RC);
         } else if (which == Dialog.BUTTON_NEGATIVE) {
             setResult(Activity.RESULT_CANCELED);


### PR DESCRIPTION
Added features as discussed in #230.

When using `setOpenInNewTask()` for building the dialog, the app settings screen will be opened using an Intent that has the flag `Intent.FLAG_ACTIVITY_NEW_TASK` added before calling startActivityForResult(). Hence the settings Activity will not appear as a screen within the task of the activity it has been opened from but instead as a separate task that can be brought to front and back separately by the user.